### PR TITLE
Change scope to provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Add "play2-oauth2-provider" to library dependencies of your project.
 
 ```scala
 libraryDependencies ++= Seq(
+  "com.nulab-inc" %% "scala-oauth2-provider" % "1.3.0",
   "com.nulab-inc" %% "play2-oauth2-provider" % "1.2.0"
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val root = Project(
     description := "Support scala-oauth2-core library on Playframework Scala",
     version := "1.2.1-SNAPSHOT",
     libraryDependencies ++= Seq(
-      "com.nulab-inc" %% "scala-oauth2-core" % "1.3.0",
+      "com.nulab-inc" %% "scala-oauth2-core" % "1.3.0" % "provided",
       "com.typesafe.play" %% "play" % playVersion % "provided",
       "com.typesafe.play" %% "play-test" % playVersion % "test"
     ) ++ commonDependenciesInTestScope


### PR DESCRIPTION
Separated project from scala-oauth2-provider, so release version also will be different between core and Play module. This PR changes scope of`libraryDependencies` for scala-oauth2-provider.