### PR TITLE
Support Play 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ libraryDependencies ++= Seq(
 
 Library version | Play version
 --------------- | ------------
+1.3.0           | 2.6.x
 1.2.0           | 2.5.x
 0.16.1          | 2.4.x
 0.14.0          | 2.3.x
@@ -78,12 +79,14 @@ POST    /oauth2/access_token                    controllers.OAuth2Controller.acc
 Finally, you can access to an authorized resource like this:
 
 ```scala
-import scalaoauth2.provider._
-object MyController extends Controller with OAuth2Provider {
-  def list = Action.async { implicit request =>
-    authorize(new MyDataHandler()) { authInfo =>
+class MyController @Inject() (components: ControllerComponents)
+  extends AbstractController(components) with OAuth2Provider {
+
+  val action = Action.async { request =>
+    authorize(new MockDataHandler()) { authInfo =>
       val user = authInfo.user // User is defined on your system
       // access resource for the user
+      ???
     }
   }
 }
@@ -95,12 +98,11 @@ If you'd like to change the OAuth workflow, modify handleRequest methods of `Tok
 
 You can write more easily authorize action by using Action composition.
 
-Play Framework's documentation is [here](https://www.playframework.com/documentation/2.5.x/ScalaActionsComposition).
+Play Framework's documentation is [here](https://www.playframework.com/documentation/2.6.x/ScalaActionsComposition).
 
 ```scala
-object MyController extends Controller {
-
-  import scalaoauth2.provider.OAuth2ProviderActionBuilders._
+class MyController @Inject() (components: ControllerComponents)
+  extends AbstractController(components) with OAuth2ProviderActionBuilders {
 
   def list = AuthorizedAction(new MyDataHandler()) { request =>
     val user = request.authInfo.user // User is defined on your system

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
-val playVersion = "2.5.10"
+val playVersion = "2.6.0-RC2"
 val commonDependenciesInTestScope = Seq(
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "ch.qos.logback" % "logback-classic" % "1.1.8" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.3" % "test",
+  "ch.qos.logback" % "logback-classic" % "1.2.3" % "test"
 )
 
 val unusedWarnings = Seq(
@@ -14,8 +14,8 @@ lazy val scalaOAuth2ProviderSettings =
     scalariformSettings ++
     Seq(
       organization := "com.nulab-inc",
-      scalaVersion := "2.11.8",
-      crossScalaVersions := Seq("2.11.8"),
+      scalaVersion := "2.11.11",
+      crossScalaVersions := Seq("2.11.11", "2.12.2"),
       scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature"),
       scalacOptions ++= unusedWarnings,
       publishTo := {
@@ -58,7 +58,7 @@ lazy val root = Project(
     description := "Support scala-oauth2-core library on Playframework Scala",
     version := "1.2.1-SNAPSHOT",
     libraryDependencies ++= Seq(
-      "com.nulab-inc" % "scala-oauth2-core_2.11" % "1.2.0",
+      "com.nulab-inc" %% "scala-oauth2-core" % "1.3.0",
       "com.typesafe.play" %% "play" % playVersion % "provided",
       "com.typesafe.play" %% "play-test" % playVersion % "test"
     ) ++ commonDependenciesInTestScope

--- a/src/main/scala/scalaoauth2/provider/AuthorizedActionFunction.scala
+++ b/src/main/scala/scalaoauth2/provider/AuthorizedActionFunction.scala
@@ -4,7 +4,10 @@ import play.api.mvc._
 
 import scala.concurrent.{ Future, ExecutionContext }
 
-case class AuthorizedActionFunction[U](handler: ProtectedResourceHandler[U])(implicit ctx: ExecutionContext) extends ActionFunction[Request, ({ type L[A] = AuthInfoRequest[A, U] })#L] with OAuth2Provider {
+case class AuthorizedActionFunction[U](handler: ProtectedResourceHandler[U])(implicit ctx: ExecutionContext)
+    extends ActionFunction[Request, ({ type L[A] = AuthInfoRequest[A, U] })#L] with OAuth2Provider {
+
+  override protected def executionContext: ExecutionContext = ctx
 
   override def invokeBlock[A](request: Request[A], block: AuthInfoRequest[A, U] => Future[Result]): Future[Result] = {
     authorize(handler) { authInfo =>

--- a/src/main/scala/scalaoauth2/provider/OAuth2ProviderActionBuilders.scala
+++ b/src/main/scala/scalaoauth2/provider/OAuth2ProviderActionBuilders.scala
@@ -1,19 +1,13 @@
 package scalaoauth2.provider
 
-import play.api.mvc._
-
-import scala.concurrent.ExecutionContext
+import play.api.mvc.{ ActionBuilder, AnyContent, BaseController }
 
 trait OAuth2ProviderActionBuilders {
 
-  implicit val executionContext: ExecutionContext
+  self: BaseController =>
 
-  def AuthorizedAction[U](handler: ProtectedResourceHandler[U]): ActionBuilder[({ type L[A] = AuthInfoRequest[A, U] })#L] = {
-    AuthorizedActionFunction(handler) compose Action
+  def AuthorizedAction[U](handler: ProtectedResourceHandler[U]): ActionBuilder[({ type L[A] = AuthInfoRequest[A, U] })#L, AnyContent] = {
+    AuthorizedActionFunction(handler)(self.defaultExecutionContext) compose Action
   }
 
-}
-
-object OAuth2ProviderActionBuilders extends OAuth2ProviderActionBuilders {
-  implicit val executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
 }

--- a/src/test/scala/scalaoauth2/provider/OAuth2ProviderActionBuildersSpec.scala
+++ b/src/test/scala/scalaoauth2/provider/OAuth2ProviderActionBuildersSpec.scala
@@ -1,21 +1,31 @@
 package scalaoauth2.provider
 
+import javax.inject.Inject
+
 import org.scalatest._
 import org.scalatest.Matchers._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.{ AbstractController, ControllerComponents }
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
-import play.api.mvc.Results._
 
 class OAuth2ProviderActionBuildersSpec extends FlatSpec {
 
-  import OAuth2ProviderActionBuilders._
+  class MyController @Inject() (components: ControllerComponents)
+      extends AbstractController(components) with OAuth2ProviderActionBuilders {
 
-  val action = AuthorizedAction(new MockDataHandler) { request =>
-    Ok(request.authInfo.user.name)
+    val action = AuthorizedAction(new MockDataHandler) { request =>
+      Ok(request.authInfo.user.name)
+    }
+
   }
 
+  val injector = new GuiceApplicationBuilder().injector()
+  val controllerComponents = injector.instanceOf[ControllerComponents]
+
   it should "return BadRequest" in {
-    val result = action(FakeRequest())
+    val controller = new MyController(controllerComponents)
+    val result = controller.action(FakeRequest())
     status(result) should be(400)
     contentAsString(result) should be("")
   }


### PR DESCRIPTION
- [x] Add support Play 2.6 to README.md

Added temporary resolvers for Akka.
It should be removed.

```
resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/",
```