### PR TITLE
Fixed bug in responseAccessToken

### DIFF
--- a/src/main/scala/scalaoauth2/provider/OAuth2Provider.scala
+++ b/src/main/scala/scalaoauth2/provider/OAuth2Provider.scala
@@ -131,7 +131,7 @@ trait OAuth2TokenEndpointProvider extends OAuth2BaseProvider {
         "refresh_token" -> JsString(_)
       } ++ r.scope.map {
         "scope" -> JsString(_)
-      }
+      } ++ r.params.map(e => (e._1, JsString(e._2)))
   }
 
 }


### PR DESCRIPTION
Fixed bug where the params Map() didn't get added to the responseAccessToken.